### PR TITLE
The most significant changes include the addition of a new button in `Index.razor` to reinstall a service if it's down, providing an additional recovery option for users. In `StopMessageReader.cs`, the timer initialization and start code has been moved inside a conditional block to ensure it only starts if the operation hasn't been cancelled. This change also includes stopping the timer before detaching the `ExitTimerElapsed` event to prevent potential race conditions. In `ServiceUnInstallationReport.cs` and `Orchestrator.cs`, the `RemoveMicroServiceInfo` method has been updated to include a new boolean parameter and to conditionally remove the service from the list, respectively.

### DIFF
--- a/src/Palace.Server/MessageReaders/ServiceUnInstallationReport.cs
+++ b/src/Palace.Server/MessageReaders/ServiceUnInstallationReport.cs
@@ -52,7 +52,7 @@ public class ServiceUnInstallationReport(
 		}
 
 		// On supprime le service de la liste
-		orchestrator.RemoveMicroServiceInfo(emsi);
+		orchestrator.RemoveMicroServiceInfo(emsi, true);
 
 		await longActionService.SetActionCompleted(new Models.ActionResult
 		{

--- a/src/Palace.Server/Services/HealthCheckerService.cs
+++ b/src/Palace.Server/Services/HealthCheckerService.cs
@@ -26,7 +26,8 @@ public class HealthCheckerService(
 		var services = orchestrator.GetServiceList();
 		foreach (var service in services)
 		{
-			if (service.LastHitDate < DateTime.Now.AddMinutes(-1))
+			if (!service.LastHitDate.HasValue
+				|| service.LastHitDate < DateTime.Now.AddMinutes(-1))
 			{
 				logger.LogWarning("Service {serviceName} is down", service.ServiceName);
 				service.ServiceState = Palace.Shared.ServiceState.Down;

--- a/src/Palace.Server/Services/Orchestrator.cs
+++ b/src/Palace.Server/Services/Orchestrator.cs
@@ -181,14 +181,17 @@ public class Orchestrator(
 		}
 	}
 
-	internal void RemoveMicroServiceInfo(ExtendedMicroServiceInfo rmi)
+	internal void RemoveMicroServiceInfo(ExtendedMicroServiceInfo rmi, bool fromUninstall)
 	{
 		if (rmi is null)
 		{
 			return;
 		}
 
-		// _extendedMicroServiceInfoList.Remove(rmi.Key, out var existing);
+		if (fromUninstall)
+		{
+			_extendedMicroServiceInfoList.Remove(rmi.Key, out var existing);
+		}
 		try
 		{
 			ServiceChanged?.Invoke(rmi);

--- a/src/Palace.WebApp/Pages/Index.razor
+++ b/src/Palace.WebApp/Pages/Index.razor
@@ -98,6 +98,7 @@
 							{
 								<LongActionButton type="button" ButtonType="btn-primary" CreateLongAction="(() => CreateStartAction(service, serviceInfo))">Start</LongActionButton>
 								<LongActionButton type="button" ButtonType="btn-danger" CreateLongAction="(() => CreateUnInstallServiceAction(host, service))">UnInstall</LongActionButton>
+								<LongActionButton type="button" ButtonType="btn-danger" CreateLongAction="(() => CreateInstallServiceAction(host, service))">Reinstall</LongActionButton>
 							}
 							else if (serviceInfo.ServiceState == ServiceState.InstallationFailed)
 							{

--- a/src/Palace.WebApp/Palace.WebApp.csproj
+++ b/src/Palace.WebApp/Palace.WebApp.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>3.3.15.0</Version>
+    <Version>3.3.16.0</Version>
     <PackageReleaseNotes>
 			3.3.15.0 : Best timeouts
 			3.3.14.0 : Display queues and topics


### PR DESCRIPTION
1. In `StopMessageReader.cs`, the timer initialization and start code has been moved inside a conditional block to ensure it only starts if the operation hasn't been cancelled. The timer is now stopped before the `ExitTimerElapsed` event is detached to prevent potential race conditions.
2. In `ServiceUnInstallationReport.cs`, the `RemoveMicroServiceInfo` method call has been updated to include a new boolean parameter, indicating whether the service is being removed due to an uninstallation.
3. In `HealthCheckerService.cs`, the condition to check if a service is down has been updated to also check if the `LastHitDate` is null, preventing potential null reference exceptions.
4. In `Orchestrator.cs`, the `RemoveMicroServiceInfo` method has been updated to only remove the service from the `_extendedMicroServiceInfoList` if the `fromUninstall` parameter is true, preventing the service from being removed from the list in certain scenarios.
5. In `Index.razor`, a new button has been added to reinstall a service if its state is down, providing an additional recovery option for users.
6. In `Palace.WebApp.csproj`, the version number of the project has been incremented from `3.3.15.0` to `3.3.16.0`, indicating a new release of the project with the above changes.